### PR TITLE
Add EC2 deployment automation for Boot2Qt builds

### DIFF
--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -84,6 +84,12 @@ jobs:
             exit 1
           fi
       
+      - name: Checkout repository for deployment scripts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Deploy to EC2 instance
         env:
           EC2_KEY_NAME: ${{ secrets.EC2_KEY_NAME }}

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -56,6 +56,12 @@ jobs:
           echo "Build logs: $LOG_URL"
           echo "Build completed successfully! Check AWS CodeBuild console for detailed logs."
       
+      - name: Checkout repository for deployment scripts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Download build artifacts for deployment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -83,12 +89,6 @@ jobs:
             echo "No tarball found in release"
             exit 1
           fi
-      
-      - name: Checkout repository for deployment scripts
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Deploy to EC2 instance
         env:

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -56,6 +56,54 @@ jobs:
           echo "Build logs: $LOG_URL"
           echo "Build completed successfully! Check AWS CodeBuild console for detailed logs."
       
+      - name: Download build artifacts for deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Downloading build artifacts from GitHub release..."
+          
+          # Get the build number from CodeBuild
+          BUILD_NUMBER=$(aws codebuild batch-get-builds --ids "$BUILD_ID" --query 'builds[0].buildNumber' --output text)
+          RELEASE_TAG="boot2qt-build-${BUILD_NUMBER}"
+          
+          echo "Downloading from release: $RELEASE_TAG"
+          
+          # Download the tarball from the GitHub release
+          gh release download "$RELEASE_TAG" --pattern "antares-cluster-boot2qt-*.tar.gz"
+          
+          # Create artifacts directory and extract
+          mkdir -p build-artifacts
+          TARBALL=$(ls antares-cluster-boot2qt-*.tar.gz | head -1)
+          
+          if [ -f "$TARBALL" ]; then
+            tar -xzf "$TARBALL" -C build-artifacts/
+            echo "Build artifacts extracted successfully"
+            ls -la build-artifacts/
+          else
+            echo "No tarball found in release"
+            exit 1
+          fi
+      
+      - name: Deploy to EC2 instance
+        env:
+          EC2_KEY_NAME: ${{ secrets.EC2_KEY_NAME }}
+          EC2_SECURITY_GROUP: ${{ secrets.EC2_SECURITY_GROUP }}
+          EC2_SUBNET_ID: ${{ secrets.EC2_SUBNET_ID }}
+        run: |
+          echo "Deploying successful build to EC2 instance..."
+          
+          # Make deployment script executable
+          chmod +x .github/workflows/deploy-to-ec2.sh
+          
+          # Set up SSH key
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          
+          # Run deployment
+          ./.github/workflows/deploy-to-ec2.sh
+      
+      
       - name: Checkout repository for Claude Code analysis
         if: failure() && env.FAILED_BUILD_ID
         uses: actions/checkout@v4

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -69,7 +69,7 @@ jobs:
           echo "Downloading from release: $RELEASE_TAG"
           
           # Download the tarball from the GitHub release
-          gh release download "$RELEASE_TAG" --pattern "antares-cluster-boot2qt-*.tar.gz"
+          gh release download "$RELEASE_TAG" --repo "${{ github.repository }}" --pattern "antares-cluster-boot2qt-*.tar.gz"
           
           # Create artifacts directory and extract
           mkdir -p build-artifacts

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -95,19 +95,29 @@ jobs:
           EC2_KEY_NAME: ${{ secrets.EC2_KEY_NAME }}
           EC2_SECURITY_GROUP: ${{ secrets.EC2_SECURITY_GROUP }}
           EC2_SUBNET_ID: ${{ secrets.EC2_SUBNET_ID }}
+          EC2_PRIVATE_KEY: ${{ secrets.EC2_PRIVATE_KEY }}
         run: |
           echo "Deploying successful build to EC2 instance..."
           
           # Make deployment script executable
           chmod +x .github/workflows/deploy-to-ec2.sh
           
-          # Set up SSH key
-          mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          
           # Run deployment
           ./.github/workflows/deploy-to-ec2.sh
+      
+      - name: Wait and cleanup EC2 instance
+        if: success()
+        run: |
+          echo "Waiting 10 minutes for testing, then cleaning up EC2 instance..."
+          sleep 600  # Wait 10 minutes
+          
+          if [ -n "$INSTANCE_ID" ]; then
+            echo "Terminating EC2 instance: $INSTANCE_ID"
+            aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"
+            echo "Instance $INSTANCE_ID terminated"
+          else
+            echo "No instance ID found to terminate"
+          fi
       
       
       - name: Checkout repository for Claude Code analysis

--- a/.github/workflows/deploy-to-ec2.sh
+++ b/.github/workflows/deploy-to-ec2.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# EC2 Deployment Script for Boot2Qt Application
+# Deploys successful builds to AWS EC2 instance with Boot2Qt AMI
+
+set -e
+
+# Configuration
+AMI_ID="ami-0c02fb55956c7d316"  # Boot2Qt 6.8.3 AMI for us-east-1
+INSTANCE_TYPE="g5g.large"       # GPU-enabled ARM64 instance
+REGION="us-east-1"              # AWS region
+KEY_NAME="${EC2_KEY_NAME}"      # SSH key pair name
+SECURITY_GROUP="${EC2_SECURITY_GROUP:-boot2qt-sg}"
+SUBNET_ID="${EC2_SUBNET_ID}"    # Optional: specify subnet
+
+echo "Starting EC2 deployment process..."
+
+# Function to create security group if it doesn't exist
+create_security_group() {
+    if ! aws ec2 describe-security-groups --group-names "$SECURITY_GROUP" --region "$REGION" >/dev/null 2>&1; then
+        echo "Creating security group: $SECURITY_GROUP"
+        SECURITY_GROUP_ID=$(aws ec2 create-security-group \
+            --group-name "$SECURITY_GROUP" \
+            --description "Security group for Boot2Qt deployment" \
+            --region "$REGION" \
+            --query 'GroupId' --output text)
+        
+        # Add SSH access
+        aws ec2 authorize-security-group-ingress \
+            --group-id "$SECURITY_GROUP_ID" \
+            --protocol tcp --port 22 --cidr 0.0.0.0/0 \
+            --region "$REGION"
+        
+        # Add Qt debugging ports (if needed)
+        aws ec2 authorize-security-group-ingress \
+            --group-id "$SECURITY_GROUP_ID" \
+            --protocol tcp --port 3768 --cidr 0.0.0.0/0 \
+            --region "$REGION"
+        
+        echo "Security group created: $SECURITY_GROUP_ID"
+    else
+        echo "Security group $SECURITY_GROUP already exists"
+        SECURITY_GROUP_ID=$(aws ec2 describe-security-groups \
+            --group-names "$SECURITY_GROUP" \
+            --region "$REGION" \
+            --query 'SecurityGroups[0].GroupId' --output text)
+    fi
+}
+
+# Function to launch EC2 instance
+launch_instance() {
+    echo "Launching EC2 instance..."
+    
+    # Build launch command
+    LAUNCH_CMD="aws ec2 run-instances \
+        --image-id $AMI_ID \
+        --instance-type $INSTANCE_TYPE \
+        --key-name $KEY_NAME \
+        --security-group-ids $SECURITY_GROUP_ID \
+        --region $REGION \
+        --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=antares-boot2qt-deployment},{Key=Project,Value=antares},{Key=Environment,Value=staging}]'"
+    
+    # Add subnet if specified
+    if [ -n "$SUBNET_ID" ]; then
+        LAUNCH_CMD="$LAUNCH_CMD --subnet-id $SUBNET_ID"
+    fi
+    
+    # Launch instance
+    INSTANCE_ID=$(eval $LAUNCH_CMD --query 'Instances[0].InstanceId' --output text)
+    echo "Instance launched: $INSTANCE_ID"
+    
+    # Wait for instance to be running
+    echo "Waiting for instance to be running..."
+    aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$REGION"
+    
+    # Get public IP
+    PUBLIC_IP=$(aws ec2 describe-instances \
+        --instance-ids "$INSTANCE_ID" \
+        --region "$REGION" \
+        --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+    
+    echo "Instance is running at: $PUBLIC_IP"
+    echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+    echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
+}
+
+# Function to wait for SSH availability
+wait_for_ssh() {
+    echo "Waiting for SSH to be available..."
+    for i in {1..30}; do
+        if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" 'echo "SSH connection successful"' >/dev/null 2>&1; then
+            echo "SSH is available"
+            return 0
+        fi
+        echo "Attempt $i: SSH not ready, waiting 10 seconds..."
+        sleep 10
+    done
+    echo "Error: SSH connection failed after 5 minutes"
+    exit 1
+}
+
+# Function to deploy application
+deploy_application() {
+    echo "Deploying application to EC2 instance..."
+    
+    # Create deployment directory on target
+    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" '
+        mkdir -p /opt/antares
+        cd /opt/antares
+    '
+    
+    # Copy application files
+    echo "Copying application files..."
+    scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa -r ./build-artifacts/* root@"$PUBLIC_IP":/opt/antares/
+    
+    # Set executable permissions and run
+    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" '
+        cd /opt/antares
+        chmod +x ClusterApp deploy.sh
+        
+        # Set environment for GPU acceleration
+        export QT_QPA_PLATFORM=eglfs
+        export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
+        
+        echo "Application deployed successfully"
+        echo "To run the cluster app: ./ClusterApp"
+        echo "Or use the deployment script: ./deploy.sh"
+        
+        # Start the application (background process)
+        nohup ./ClusterApp > cluster.log 2>&1 &
+        
+        echo "Cluster application started in background"
+        echo "Cluster log: /opt/antares/cluster.log"
+        echo "Build info: /opt/antares/build_info.txt"
+    '
+    
+    echo "Deployment completed successfully!"
+    echo "Access the instance via SSH: ssh -i ~/.ssh/id_rsa root@$PUBLIC_IP"
+    echo "Application directory: /opt/antares"
+}
+
+# Main execution
+main() {
+    # Validate required environment variables
+    if [ -z "$KEY_NAME" ]; then
+        echo "Error: EC2_KEY_NAME environment variable is required"
+        exit 1
+    fi
+    
+    # Check if build artifacts exist
+    if [ ! -d "./build-artifacts" ]; then
+        echo "Error: build-artifacts directory not found"
+        exit 1
+    fi
+    
+    # Execute deployment steps
+    create_security_group
+    launch_instance
+    wait_for_ssh
+    deploy_application
+    
+    echo "EC2 deployment completed successfully!"
+    echo "Instance ID: $INSTANCE_ID"
+    echo "Public IP: $PUBLIC_IP"
+}
+
+# Run main function
+main "$@"

--- a/.github/workflows/deploy-to-ec2.sh
+++ b/.github/workflows/deploy-to-ec2.sh
@@ -7,7 +7,7 @@ set -e
 
 # Configuration
 AMI_ID="ami-0925b4f9cda817f8a"  # Boot2Qt 6.8 AMI for us-east-1
-INSTANCE_TYPE="g5g.large"       # GPU-enabled ARM64 instance
+INSTANCE_TYPE="g5g.xlarge"       # GPU-enabled ARM64 instance
 REGION="us-east-1"              # AWS region
 KEY_NAME="${EC2_KEY_NAME}"      # SSH key pair name
 SECURITY_GROUP="${EC2_SECURITY_GROUP:-boot2qt-sg}"

--- a/.github/workflows/deploy-to-ec2.sh
+++ b/.github/workflows/deploy-to-ec2.sh
@@ -88,7 +88,7 @@ launch_instance() {
 wait_for_ssh() {
     echo "Waiting for SSH to be available..."
     for i in {1..30}; do
-        if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" 'echo "SSH connection successful"' >/dev/null 2>&1; then
+        if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa user@"$PUBLIC_IP" 'echo "SSH connection successful"' >/dev/null 2>&1; then
             echo "SSH is available"
             return 0
         fi
@@ -104,17 +104,17 @@ deploy_application() {
     echo "Deploying application to EC2 instance..."
     
     # Create deployment directory on target
-    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" '
+    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa user@"$PUBLIC_IP" '
         mkdir -p /opt/antares
         cd /opt/antares
     '
     
     # Copy application files
     echo "Copying application files..."
-    scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa -r ./build-artifacts/* root@"$PUBLIC_IP":/opt/antares/
+    scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa -r ./build-artifacts/* user@"$PUBLIC_IP":/opt/antares/
     
     # Set executable permissions and run
-    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa root@"$PUBLIC_IP" '
+    ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa user@"$PUBLIC_IP" '
         cd /opt/antares
         chmod +x ClusterApp deploy.sh
         
@@ -135,7 +135,7 @@ deploy_application() {
     '
     
     echo "Deployment completed successfully!"
-    echo "Access the instance via SSH: ssh -i ~/.ssh/id_rsa root@$PUBLIC_IP"
+    echo "Access the instance via SSH: ssh -i ~/.ssh/id_rsa user@$PUBLIC_IP"
     echo "Application directory: /opt/antares"
 }
 

--- a/.github/workflows/deploy-to-ec2.sh
+++ b/.github/workflows/deploy-to-ec2.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-AMI_ID="ami-0c02fb55956c7d316"  # Boot2Qt 6.8.3 AMI for us-east-1
+AMI_ID="ami-0925b4f9cda817f8a"  # Boot2Qt 6.8 AMI for us-east-1
 INSTANCE_TYPE="g5g.large"       # GPU-enabled ARM64 instance
 REGION="us-east-1"              # AWS region
 KEY_NAME="${EC2_KEY_NAME}"      # SSH key pair name

--- a/EC2_DEPLOYMENT_README.md
+++ b/EC2_DEPLOYMENT_README.md
@@ -1,0 +1,128 @@
+# EC2 Deployment Setup
+
+This document explains how to configure AWS EC2 deployment for the Antares Boot2Qt application.
+
+## Prerequisites
+
+1. **AWS Account** with appropriate permissions
+2. **Boot2Qt 6.8 AMI** subscription from AWS Marketplace
+3. **EC2 Key Pair** for SSH access
+4. **GitHub Secrets** configured (see below)
+
+## Required GitHub Secrets
+
+Add these secrets to your GitHub repository settings:
+
+### Required Secrets
+- `EC2_KEY_NAME`: Name of your EC2 key pair (e.g., "antares-deployment-key")
+- `EC2_PRIVATE_KEY`: Private key content (PEM format) for SSH access
+
+### Optional Secrets
+- `EC2_SECURITY_GROUP`: Security group name (defaults to "boot2qt-sg")
+- `EC2_SUBNET_ID`: Specific subnet ID for instance placement
+
+## Setup Steps
+
+### 1. Subscribe to Boot2Qt AMI
+1. Visit [Boot2Qt 6.8 AMI on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-t5ktjcktc7izy)
+2. Click "Continue to Subscribe"
+3. Accept terms and configure pricing
+
+### 2. Create EC2 Key Pair
+```bash
+# Create new key pair
+aws ec2 create-key-pair --key-name antares-deployment-key --query 'KeyMaterial' --output text > antares-deployment-key.pem
+chmod 400 antares-deployment-key.pem
+
+# Add the private key content to GitHub Secrets as EC2_PRIVATE_KEY
+cat antares-deployment-key.pem
+```
+
+### 3. Configure GitHub Secrets
+1. Go to your repository's Settings → Secrets and variables → Actions
+2. Add the required secrets:
+   - `EC2_KEY_NAME`: `antares-deployment-key`
+   - `EC2_PRIVATE_KEY`: Content of your `.pem` file
+
+### 4. Update AMI ID (if needed)
+The deployment script uses a default AMI ID. Update it in `.github/workflows/deploy-to-ec2.sh` if needed:
+```bash
+AMI_ID="ami-0c02fb55956c7d316"  # Update for your region
+```
+
+## Deployment Process
+
+When code is pushed to `main`:
+
+1. **Build**: GitHub Actions triggers AWS CodeBuild
+2. **Success**: Downloads build artifacts from S3
+3. **Deploy**: Launches new EC2 instance with Boot2Qt AMI
+4. **Install**: Copies and runs the application
+5. **Summary**: Provides SSH access details
+
+## Instance Configuration
+
+- **Instance Type**: g5g.large (ARM64 with GPU)
+- **AMI**: Boot2Qt 6.8.3 for ARM64
+- **Security Group**: Allows SSH (port 22) and Qt debugging (port 3768)
+- **Application Path**: `/opt/antares/`
+
+## Accessing the Deployed Application
+
+After successful deployment:
+
+```bash
+# SSH into the instance
+ssh -i your-key.pem root@<PUBLIC_IP>
+
+# Navigate to application directory
+cd /opt/antares
+
+# Run applications
+./GLOApp         # Cluster application
+./QtMediaSwipeApp # IVI application
+
+# Check logs
+tail -f cluster.log
+tail -f ivi.log
+```
+
+## Cost Management
+
+- **Instance Cost**: ~$0.25/hour for g5g.large + Boot2Qt licensing
+- **Auto-termination**: Consider adding instance auto-termination for cost control
+- **Monitoring**: Set up CloudWatch billing alerts
+
+## Troubleshooting
+
+### SSH Connection Issues
+```bash
+# Verify security group allows SSH
+aws ec2 describe-security-groups --group-names boot2qt-sg
+
+# Check instance status
+aws ec2 describe-instances --instance-ids <INSTANCE_ID>
+```
+
+### Application Issues
+```bash
+# Check if applications are running
+ps aux | grep -E "(GLOApp|QtMediaSwipeApp)"
+
+# Check Qt environment
+echo $QT_QPA_PLATFORM
+echo $QT_QPA_EGLFS_INTEGRATION
+```
+
+### Build Artifacts Missing
+- Verify CodeBuild project outputs artifacts to S3
+- Check S3 bucket permissions
+- Ensure build script creates the expected binaries
+
+## Security Notes
+
+- Instances are launched with public IPs for easy access
+- Consider using private subnets with bastion hosts for production
+- Regularly rotate SSH keys
+- Monitor instance access logs
+- Use IAM roles instead of hardcoded credentials where possible


### PR DESCRIPTION
## Summary
- Adds automated EC2 deployment for successful Boot2Qt builds
- Integrates with existing GitHub Actions workflow to deploy artifacts to AWS
- Includes automatic instance cleanup after testing period

## Changes
- Modified `.github/workflows/boot2qt-build.yml` to include EC2 deployment steps
- Added `deploy-to-ec2.sh` script for automated instance provisioning and deployment
- Created comprehensive documentation in `EC2_DEPLOYMENT_README.md`

## Features
- Automatic EC2 instance launch with Boot2Qt AMI
- Secure SSH deployment using GitHub Secrets
- Application deployment to `/opt/antares/` directory
- 10-minute testing window with automatic cleanup
- Security group and networking configuration