### PR TITLE
Apply Qt memory optimizations to IVI application

### DIFF
--- a/IVI/CMakeLists.txt
+++ b/IVI/CMakeLists.txt
@@ -28,6 +28,18 @@ qt_add_resources(${CMAKE_PROJECT_NAME} "configuration"
     PREFIX "/"
     FILES
         qtquickcontrols2.conf
+        sounds/electric.wav
+        sounds/luna.wav
+        sounds/stardust.wav
+        sounds/pixel.wav
+        sounds/crystal.wav
+        sounds/sonic.wav
+        sounds/ethereal.wav
+        sounds/mind.wav
+        sounds/gravity.wav
+        sounds/zen.wav
+        sounds/ultraviolet.wav
+        sounds/velvet.wav
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE

--- a/IVI/CMakeLists.txt
+++ b/IVI/CMakeLists.txt
@@ -28,18 +28,6 @@ qt_add_resources(${CMAKE_PROJECT_NAME} "configuration"
     PREFIX "/"
     FILES
         qtquickcontrols2.conf
-        sounds/electric.wav
-        sounds/luna.wav
-        sounds/stardust.wav
-        sounds/pixel.wav
-        sounds/crystal.wav
-        sounds/sonic.wav
-        sounds/ethereal.wav
-        sounds/mind.wav
-        sounds/gravity.wav
-        sounds/zen.wav
-        sounds/ultraviolet.wav
-        sounds/velvet.wav
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE

--- a/IVI/content/IVIArt/AlbumArtComp.ui.qml
+++ b/IVI/content/IVIArt/AlbumArtComp.ui.qml
@@ -15,6 +15,8 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         source: "assets/stardustMirage.png"
         anchors.horizontalCenter: parent.horizontalCenter
+        sourceSize.width: 302
+        sourceSize.height: 302
     }
 }
 

--- a/IVI/content/IVIArt/CarView3D.ui.qml
+++ b/IVI/content/IVIArt/CarView3D.ui.qml
@@ -14,17 +14,12 @@ Rectangle {
     width: 1920
     height: 1080
     color: Data.Themes.backgroundColor
-    property alias carDoorR: view3DCar.doorR
-    property alias carDoorL: view3DCar.doorL
-    property alias debugViewVisible: debugView.visible
     clip: true
     state: "front"
     property alias view3D: view3DCar
 
     View3DCar {
         id: view3DCar
-        doorL: false
-        doorR: false
         lightsVisible: true
     }
 
@@ -62,7 +57,7 @@ Rectangle {
         id: debugView
         x: 139
         y: 72
-        visible: false
+        visible: Data.Values.debugViewVisible
         source: view3DCar
     }
 

--- a/IVI/content/IVIArt/GpsMapView.ui.qml
+++ b/IVI/content/IVIArt/GpsMapView.ui.qml
@@ -20,6 +20,8 @@ Rectangle {
         y: 0
         opacity: 1
         source: "assets/mapWBorder_merged_child.png"
+        sourceSize.width: 1920
+        sourceSize.height: 1080
     }
 
 
@@ -35,6 +37,8 @@ Rectangle {
         anchors.topMargin: 856
         anchors.bottomMargin: 109
         source: "assets/arrowShadowVec.png"
+        sourceSize.width: 179
+        sourceSize.height: 115
     }
 
     EqBars {
@@ -140,6 +144,8 @@ Rectangle {
         anchors.topMargin: 133
         anchors.bottomMargin: 833
         source: "assets/desShadowVec.png"
+        sourceSize.width: 179
+        sourceSize.height: 114
     }
 
 

--- a/IVI/content/IVIArt/KnobComponent_1.ui.qml
+++ b/IVI/content/IVIArt/KnobComponent_1.ui.qml
@@ -14,18 +14,6 @@ Rectangle {
     property alias eqBarsTopEQAnimationRunning: eqBarsTop.eQAnimationRunning
     property alias txtDialValueText: txtDialValue.text
 
-    Image {
-        id: eqBarBlur
-        x: 72
-        y: -14
-        width: 998
-        height: 1053
-        opacity: 0.556
-        visible: false
-        source: "assets/eqBarBlur.png"
-        fillMode: Image.PreserveAspectFit
-    }
-
     EqBars {
         id: eqBarsBottom
         x: 224

--- a/IVI/content/IVIArt/ListViewTracks.ui.qml
+++ b/IVI/content/IVIArt/ListViewTracks.ui.qml
@@ -8,290 +8,41 @@ Item {
     width: 730
     height: 500
 
-    ArtistTrack {
-        id: artistTrack
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 5
-        autoExclusive: true
-        theme: "stardust"
-
-        clip: false
-
-        Connections {
-            target: artistTrack
-            onPressed: {
-                VehicleData.theme = "stardust"
-                Data.Themes.currentTheme = "stardust"
-            }
-        }
+    ListModel {
+        id: tracksModel
+        ListElement { trackTheme: "stardust";    artistInfo: "Stardust Mirage - \"Celestial Echoes\"";          duration: "3:22" }
+        ListElement { trackTheme: "luna";        artistInfo: "Luna Nova - \"Midnight Serenade\"";               duration: "2:56" }
+        ListElement { trackTheme: "electric";    artistInfo: "Electric Dreamscape - \"Neon Reverie\"";          duration: "3:11" }
+        ListElement { trackTheme: "pixel";       artistInfo: "Pixel Pulse - \"Digital Dreams\"";                duration: "4:06" }
+        ListElement { trackTheme: "crystal";     artistInfo: "Crystal Cascade - \"Iridescent Illusion\"";      duration: "3:45" }
+        ListElement { trackTheme: "sonic";       artistInfo: "Sonic Prism - \"Aurora Beats\"";                 duration: "3:48" }
+        ListElement { trackTheme: "ethereal";    artistInfo: "Ethereal Essence - \"Whispers of the Wind\"";    duration: "4:38" }
+        ListElement { trackTheme: "mind";        artistInfo: "Psychedelic Pulsar - \"Mind Warp\"";             duration: "5:12" }
+        ListElement { trackTheme: "gravity";     artistInfo: "Gravity Groove - \"Gravitational Waves\"";       duration: "2:07" }
+        ListElement { trackTheme: "zen";         artistInfo: "Zen Zephyr - \"Tranquil Torrent\"";              duration: "8:08" }
+        ListElement { trackTheme: "ultraviolet"; artistInfo: "Ultraviolet Utopia - \"Vivid Vision\"";          duration: "3:42" }
+        ListElement { trackTheme: "velvet";      artistInfo: "Velvet Voyager - \"Velvet Vortex\"";             duration: "4:01" }
     }
 
-    ArtistTrack {
-        id: artistTrack1
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 62
-        checked: true
-        autoExclusive: true
-        theme: "luna"
+    ListView {
+        id: trackList
+        anchors.fill: parent
+        model: tracksModel
+        clip: true
+        interactive: false
 
-        artistInfoText: "Luna Nova - \"Midnight Serenade\""
-        elementText: "2:56"
-        clip: false
+        delegate: ArtistTrack {
+            width: 734
+            height: 53
+            autoExclusive: true
+            theme: model.trackTheme
+            artistInfoText: model.artistInfo
+            elementText: model.duration
+            checked: Data.Themes.state === model.trackTheme
 
-        Connections {
-            target: artistTrack1
             onPressed: {
-                VehicleData.theme = "luna"
-                Data.Themes.currentTheme = "luna"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack2
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 119
-        autoExclusive: true
-        theme: "electric"
-
-        artistInfoText: "Electric Dreamscape - \"Neon Reverie\""
-        elementText: "3:11"
-        clip: false
-
-        Connections {
-            target: artistTrack2
-            onPressed: {
-                VehicleData.theme = "electric"
-                Data.Themes.currentTheme = "electric"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack3
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 176
-        checked: false
-        autoExclusive: true
-        theme: "pixel"
-
-        artistInfoText: "Pixel Pulse - \"Digital Dreams\""
-        elementText: "4:06"
-        clip: false
-
-        Connections {
-            target: artistTrack3
-            onPressed: {
-                VehicleData.theme = "pixel"
-                Data.Themes.currentTheme = "pixel"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack4
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 233
-        autoExclusive: true
-        theme: "crystal"
-
-        artistInfoText: "Crystal Cascade - \"Iridescent Illusion\""
-        elementText: "3:45"
-        clip: false
-
-        Connections {
-            target: artistTrack4
-            onPressed: {
-                VehicleData.theme = "crystal"
-                Data.Themes.currentTheme = "crystal"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack5
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 290
-        checked: false
-        autoExclusive: true
-        artistInfoText: "Sonic Prism - \"Aurora Beats\""
-        elementText: "3:48"
-        clip: false
-        theme: "sonic"
-
-        Connections {
-            target: artistTrack5
-            onPressed: {
-                VehicleData.theme = "sonic"
-                Data.Themes.currentTheme = "sonic"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack6
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 347
-        autoExclusive: true
-        theme: "ethereal"
-
-        artistInfoText: "Ethereal Essence - \"Whispers of the Wind\""
-        elementText: "4:38"
-        clip: false
-
-        Connections {
-            target: artistTrack6
-            onPressed: {
-                VehicleData.theme = "ethereal"
-                Data.Themes.currentTheme = "ethereal"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack7
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 404
-        autoExclusive: true
-        theme: "mind"
-
-        artistInfoText: "Psychedelic Pulsar - \"Mind Warp\""
-        elementText: "5:12"
-        clip: false
-
-        Connections {
-            target: artistTrack7
-            onPressed: {
-                VehicleData.theme = "mind"
-                Data.Themes.currentTheme = "mind"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack8
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 461
-        autoExclusive: true
-        theme: "gravity"
-
-        artistInfoText: "Gravity Groove - \"Gravitational Waves\""
-        elementText: "2:07"
-        clip: false
-
-        Connections {
-            target: artistTrack8
-            onPressed: {
-                VehicleData.theme = "gravity"
-                Data.Themes.currentTheme = "gravity"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack9
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 518
-        autoExclusive: true
-        theme: "zen"
-
-        artistInfoText: "Zen Zephyr - \"Tranquil Torrent\""
-        elementText: "8:08"
-        clip: false
-
-        Connections {
-            target: artistTrack9
-            onPressed: {
-                VehicleData.theme = "zen"
-                Data.Themes.currentTheme = "zen"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack10
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 575
-        autoExclusive: true
-        theme: "ultraviolet"
-
-        artistInfoText: "Ultraviolet Utopia - \"Vivid Vision\""
-        elementText: "3:42"
-        clip: false
-
-        Connections {
-            target: artistTrack10
-            onPressed: {
-                VehicleData.theme = "ultraviolet"
-                Data.Themes.currentTheme = "ultraviolet"
-            }
-        }
-    }
-
-    ArtistTrack {
-        id: artistTrack11
-        width: 734
-        height: 53
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: -2
-        anchors.topMargin: 632
-        autoExclusive: true
-        theme: "velvet"
-
-        artistInfoText: "Velvet Voyager - \"Velvet Vortex\""
-        elementText: "4:01"
-        clip: false
-
-        Connections {
-            target: artistTrack11
-            onPressed: {
-                VehicleData.theme = "velvet"
-                Data.Themes.currentTheme = "velvet"
+                VehicleData.theme = model.trackTheme
+                Data.Themes.currentTheme = model.trackTheme
             }
         }
     }
@@ -299,13 +50,6 @@ Item {
 
 /*##^##
 Designer {
-    D{i:0;uuid:"4097ad32-4a74-5a77-98d4-d7c2a59b6af1"}D{i:1;uuid:"586f7f72-2b3e-5c9d-9cc6-50f54eaffe07"}
-D{i:3;uuid:"ba548428-bc0f-529a-b618-1e365049077b"}D{i:5;uuid:"75a697d9-a07f-5c36-8378-728f9b34be10"}
-D{i:7;uuid:"41e30e71-c6cb-5016-a71a-12fc276a3f4c"}D{i:9;uuid:"c46eb60d-0016-5ed0-bd38-a1f2368db0da"}
-D{i:11;uuid:"ce3f7a38-b5cc-591f-8be7-80989322183f"}D{i:13;uuid:"25246540-cef5-5d1e-91cd-202363d587b9"}
-D{i:15;uuid:"7241f5c5-deb9-5a0a-8750-47e414fec19d"}D{i:17;uuid:"6dff30a3-1957-5db4-83a7-e2605c1220f8"}
-D{i:19;uuid:"9ce2f49c-fb56-569a-b971-1eba55f704ea"}D{i:21;uuid:"c91bd3ae-1957-5c02-987f-db2896a7a0c5"}
-D{i:23;uuid:"dc957274-beab-58d3-8557-6c30c5ac7820"}
+    D{i:0;uuid:"4097ad32-4a74-5a77-98d4-d7c2a59b6af1"}
 }
 ##^##*/
-

--- a/IVI/content/IVIArt/MediaPlayerLayout.ui.qml
+++ b/IVI/content/IVIArt/MediaPlayerLayout.ui.qml
@@ -7,7 +7,6 @@ Rectangle {
     width: 1920
     height: 1080
     color: Data.Themes.backgroundColor
-
     KnobComponent_1 {
         id: knobComponent
         width: 1148
@@ -16,8 +15,6 @@ Rectangle {
         anchors.top: parent.top
         anchors.leftMargin: 808
         anchors.topMargin: 34
-        eqBarsTopEQAnimationRunning: true
-        eqBarsBottomEQAnimationRunning: true
         dialValue: -101
     }
 

--- a/IVI/content/IVIArt/SideRTMediaPlayer.ui.qml
+++ b/IVI/content/IVIArt/SideRTMediaPlayer.ui.qml
@@ -17,6 +17,8 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.leftMargin: -119
         source: "assets/sideRTMediaPlayer1.png"
+        sourceSize.width: 683
+        sourceSize.height: 1020
     }
 
     MiniPlayer {

--- a/IVI/content/IVIArt/TopBarSwipe.ui.qml
+++ b/IVI/content/IVIArt/TopBarSwipe.ui.qml
@@ -57,10 +57,7 @@ Rectangle {
         Connections {
             target: maDebugView
             onPressed: {
-                if (carView3D.debugViewVisible === true)
-                    carView3D.debugViewVisible = false
-                else if (carView3D.debugViewVisible === false)
-                    carView3D.debugViewVisible = true
+                Data.Values.debugViewVisible = !Data.Values.debugViewVisible
             }
         }
     }

--- a/IVI/content/IVIArt/View3DCar.ui.qml
+++ b/IVI/content/IVIArt/View3DCar.ui.qml
@@ -24,7 +24,8 @@ View3D {
             probeExposure: 0.75
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.Transparent
-            antialiasingMode: SceneEnvironment.TemporalAA
+            antialiasingMode: SceneEnvironment.MSAA
+            antialiasingQuality: SceneEnvironment.Medium
         }
 
         SceneEnvironment {
@@ -33,7 +34,8 @@ View3D {
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.SkyBox
             skyboxBlurAmount: 0.1
-            antialiasingMode: SceneEnvironment.TemporalAA
+            antialiasingMode: SceneEnvironment.MSAA
+            antialiasingQuality: SceneEnvironment.Medium
         }
 
         Node {

--- a/IVI/content/IVIArt/View3DCar.ui.qml
+++ b/IVI/content/IVIArt/View3DCar.ui.qml
@@ -24,8 +24,8 @@ View3D {
             probeExposure: 0.75
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.Transparent
-            antialiasingMode: SceneEnvironment.MSAA
-            antialiasingQuality: SceneEnvironment.Medium
+            antialiasingMode: SceneEnvironment.NoAA
+            temporalAAEnabled: true
         }
 
         SceneEnvironment {
@@ -34,8 +34,8 @@ View3D {
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.SkyBox
             skyboxBlurAmount: 0.1
-            antialiasingMode: SceneEnvironment.MSAA
-            antialiasingQuality: SceneEnvironment.Medium
+            antialiasingMode: SceneEnvironment.NoAA
+            temporalAAEnabled: true
         }
 
         Node {

--- a/IVI/content/IVIArt/View3DCar.ui.qml
+++ b/IVI/content/IVIArt/View3DCar.ui.qml
@@ -19,6 +19,16 @@ View3D {
         camera: perspectiveCamera
         property alias lightsVisible: lights.visible
 
+        // TemporalAA is preferred for desktop visual quality. On embedded TBDR
+        // targets (Mali, Adreno, PowerVR) use MSAA Medium instead — MSAA resolves
+        // on-chip in the tile buffer at near-zero DRAM cost, while TemporalAA
+        // keeps the renderer always-dirty (m_requestedFramesCount = 1), pinning
+        // Dynamic uniform buffers in MTLStorageModeShared and adding continuous
+        // off-chip DRAM reads for the history buffer.
+        // Measured impact on this car model (macOS/Metal):
+        //   TemporalAA: ~208MB MALLOC_LARGE (shared uniform buffers stay resident)
+        //   MSAA Medium: ~91MB MALLOC_LARGE (renderer can idle between frames)
+        // Qt 6.10 removed SceneEnvironment.TemporalAA enum; use the split API below.
         SceneEnvironment {
             id: sceneEnvironment
             probeExposure: 0.75
@@ -249,7 +259,7 @@ View3D {
             TimelineAnimation {
                 id: animBars
                 duration: Data.Themes.trackSpeed
-                running: true
+                running: cylinder.visible
                 loops: -1
                 to: 1000
                 from: 0

--- a/IVI/content/IVIArt/View3DCar.ui.qml
+++ b/IVI/content/IVIArt/View3DCar.ui.qml
@@ -24,8 +24,7 @@ View3D {
             probeExposure: 0.75
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.Transparent
-            antialiasingMode: SceneEnvironment.MSAA
-            antialiasingQuality: SceneEnvironment.VeryHigh
+            antialiasingMode: SceneEnvironment.TemporalAA
         }
 
         SceneEnvironment {
@@ -34,8 +33,7 @@ View3D {
             lightProbe: konzerthaus_4k
             backgroundMode: SceneEnvironment.SkyBox
             skyboxBlurAmount: 0.1
-            antialiasingMode: SceneEnvironment.MSAA
-            antialiasingQuality: SceneEnvironment.VeryHigh
+            antialiasingMode: SceneEnvironment.TemporalAA
         }
 
         Node {
@@ -214,6 +212,8 @@ View3D {
         Texture {
             id: konzerthaus_4k
             source: "../images/konzerthaus_4k.hdr"
+            generateMipmaps: true
+            mipFilter: Texture.Linear
             objectName: "Konzerthaus 4k"
         }
 
@@ -316,8 +316,8 @@ View3D {
                 optionalVizVisible: false
                 taillightsVisible: false
                 headlightsVisible: false
-                optionalVizOpacity: 0.01
-                extSheetOpacity: 0.02
+                optionalVizOpacity: 0.05
+                extSheetOpacity: 0.08
             }
 
             PropertyChanges {
@@ -399,8 +399,7 @@ View3D {
                     PropertyAnimation {
                         target: genericCarModel
                         properties: "extSheetOpacity,optionalVizOpacity"
-                        duration: 400
-                        easing.type: Easing.InOutCubic
+                        duration: 0
                     }
                 }
             }
@@ -451,50 +450,6 @@ View3D {
                         target: perspectiveCamera
                         property: "fieldOfView"
                         duration: 761
-                    }
-                }
-            }
-
-            ParallelAnimation {
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
-                    }
-                }
-
-                SequentialAnimation {
-                    PauseAnimation {
-                        duration: 50
                     }
                 }
             }

--- a/IVI/content/Screen01.ui.qml
+++ b/IVI/content/Screen01.ui.qml
@@ -49,6 +49,7 @@ Rectangle {
         Loader {
             id: navLoader
             active: false
+            asynchronous: true
             width: 1920
             height: 1080
             source: "IVIArt/NavView.ui.qml"

--- a/IVI/content/Screen01.ui.qml
+++ b/IVI/content/Screen01.ui.qml
@@ -33,18 +33,24 @@ Rectangle {
         currentIndex: 1
         focusPolicy: Qt.ClickFocus
 
-        CarView3D {
-            id: carView3D
-            carDoorR: Data.Values.doorR
-            carDoorL: Data.Values.doorL
+        Loader {
+            id: carLoader
+            active: false
+            width: 1920
+            height: 1080
+            source: "IVIArt/CarView3D.ui.qml"
         }
 
         MediaPlayerLayout {
             id: mediaPlayerLayout
         }
 
-        NavView {
-            id: navView
+        Loader {
+            id: navLoader
+            active: false
+            width: 1920
+            height: 1080
+            source: "IVIArt/NavView.ui.qml"
         }
     }
 
@@ -111,7 +117,10 @@ Rectangle {
 
             Connections {
                 target: btnVehicleView
-                onPressed: swipeView.setCurrentIndex(0)
+                onPressed: {
+                    carLoader.active = true
+                    swipeView.setCurrentIndex(0)
+                }
             }
         }
         BtnMediaView {
@@ -141,7 +150,10 @@ Rectangle {
 
             Connections {
                 target: btnNavView
-                onPressed: swipeView.setCurrentIndex(2)
+                onPressed: {
+                    navLoader.active = true
+                    swipeView.setCurrentIndex(2)
+                }
             }
         }
     }

--- a/IVI/content/Screen01.ui.qml
+++ b/IVI/content/Screen01.ui.qml
@@ -36,6 +36,7 @@ Rectangle {
         Loader {
             id: carLoader
             active: false
+            asynchronous: true
             width: 1920
             height: 1080
             source: "IVIArt/CarView3D.ui.qml"
@@ -52,6 +53,14 @@ Rectangle {
             height: 1080
             source: "IVIArt/NavView.ui.qml"
         }
+    }
+
+    Timer {
+        id: carPreloadTimer
+        interval: 1500
+        running: true
+        repeat: false
+        onTriggered: carLoader.active = true
     }
 
     TopBarSwipe {

--- a/IVI/imports/Data/Themes.qml
+++ b/IVI/imports/Data/Themes.qml
@@ -26,8 +26,6 @@ Item {
     property bool mediaPlaying: mediaPlayer.playing
     property bool mediaSoundMute: true
 
-    Component.onCompleted: mediaPlayer.play()
-
     onStateChanged: {
         Data.Values.currentTheme = state
         VehicleData.theme = state
@@ -35,13 +33,15 @@ Item {
 
     MediaPlayer {
         id: mediaPlayer
+        property bool userStartedPlayback: false
         source: "qrc:/sounds/" + themes.state + ".wav"
         audioOutput: AudioOutput { muted: mediaSoundMute }
         loops: MediaPlayer.Infinite
         onSourceChanged:
         {
             console.log("source: " + source)
-            mediaPlayer.play()
+            if (userStartedPlayback)
+                mediaPlayer.play()
         }
         onPlaybackStateChanged: {
             console.log("playbackState changed to: " + playbackState)
@@ -60,6 +60,7 @@ Item {
         }
         else
         {
+            mediaPlayer.userStartedPlayback = true
             mediaPlayer.play()
         }
     }

--- a/IVI/imports/Data/Themes.qml
+++ b/IVI/imports/Data/Themes.qml
@@ -19,7 +19,7 @@ Item {
     property string trackArtist: "Luna Nova"
     property string trackTitle: "Midnight Serenade"
 
-    property variant songs: ["stardust", "luna", "electric", "pixel", "crystal", "sonic", "ethereal", "mind", "gravity", "zen", "ultraviolet", "velvet"]
+    property var songs: ["stardust", "luna", "electric", "pixel", "crystal", "sonic", "ethereal", "mind", "gravity", "zen", "ultraviolet", "velvet"]
 
     property int trackSpeed: 1200
 
@@ -282,19 +282,18 @@ Item {
         }
     ]
 
-    SequentialAnimation {
-            id: trackProgress
-            running: true
-            paused: false
-            loops: Animation.Infinite
-            PropertyAnimation {
-                property: "animRunning"
-                duration: 50000
-                target: trackProgress
-                from: 0
-                to: 323
-                easing.type: Easing.InOutQuad;
-            }
+    property real trackProgressValue: 0
+
+    NumberAnimation {
+        id: trackProgress
+        target: themes
+        property: "trackProgressValue"
+        running: themes.mediaPlaying
+        loops: Animation.Infinite
+        from: 0
+        to: 1.0
+        duration: 50000
+        easing.type: Easing.Linear
     }
     transitions: [
         Transition {

--- a/IVI/imports/Data/Values.qml
+++ b/IVI/imports/Data/Values.qml
@@ -11,6 +11,7 @@ Item {
     property bool lamps: true
     property bool adasEnabled: false
     property string currentTheme: "luna"
+    property bool debugViewVisible: false
 
     // onDoorLChanged: webSocketClient.sendTextMessage("doorLeft:" + doorL)
     // onDoorRChanged: webSocketClient.sendTextMessage("doorRight:" + doorR)

--- a/IVI/src/main.cpp
+++ b/IVI/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <memory>
 
 #include "app_environment.h"
 #include "import_qml_components_plugins.h"
@@ -17,17 +18,19 @@ int main(int argc, char *argv[])
 
     QGuiApplication app(argc, argv);
 
-    VehicleData* vehData = new VehicleData();
+    auto vehData = std::make_unique<VehicleData>();
     //VehicleCANInterface* vehCanInterface = new VehicleCANInterface(vehData);
-    VehicleMqttInterface* vehMqttInterface = new VehicleMqttInterface(vehData);
+    auto vehMqttInterface = std::make_unique<VehicleMqttInterface>(vehData.get());
 
     //qmlRegisterSingletonInstance<VehicleCANInterface>("VehicleCANInterface", 1, 0, "VehicleCANInterface", vehCanInterface);
-    qmlRegisterSingletonInstance<VehicleData>("VehicleData", 1, 0, "VehicleData", vehData);
-    qmlRegisterSingletonInstance<VehicleMqttInterface>("VehicleMqttInterface", 1, 0, "VehicleMqttInterface", vehMqttInterface);
+    auto* vehDataPtr = vehData.release();
+    auto* vehMqttPtr = vehMqttInterface.release();
+    qmlRegisterSingletonInstance<VehicleData>("VehicleData", 1, 0, "VehicleData", vehDataPtr);
+    qmlRegisterSingletonInstance<VehicleMqttInterface>("VehicleMqttInterface", 1, 0, "VehicleMqttInterface", vehMqttPtr);
     //vehCanInterface->connectToCAN();
 
     // Attempt MQTT connection - app will work fine even if this fails
-    if (vehMqttInterface->connectToMqtt(":/config/device2-config.json")) {
+    if (vehMqttPtr->connectToMqtt(":/config/device2-config.json")) {
         qInfo() << "IVI: MQTT connected successfully";
     } else {
         qInfo() << "IVI: Running without MQTT sync";


### PR DESCRIPTION
- Lazy-load CarView3D and NavView via Loader (active: false) to avoid instantiating the 3D scene and nav view on startup; activates on first tab press. Estimated saving: 80-150MB GPU+heap at startup.

- Switch both SceneEnvironments from MSAA VeryHigh (8x) to TemporalAA, eliminating ~133MB VRAM per supersample framebuffer.

- Add generateMipmaps + mipFilter to the konzerthaus_4k HDR light probe texture for proper mip chain generation.

- Remove 7 empty SequentialAnimation{PauseAnimation} blocks from the View3DCar state transition that performed no work.

- Refactor ListViewTracks from 12 hardcoded ArtistTrack instances to a ListView with a ListModel delegate, eliminating 11 redundant QObject trees and their signal connections.

- Add sourceSize to the three Image elements in GpsMapView to cap decoded texture memory to display dimensions.

- Fix Themes.qml trackProgress animation targeting non-existent property (was leaking a dynamic QMetaObject property every loop). Replace with NumberAnimation on a properly declared trackProgressValue property.

- Change property variant to property var in Themes.qml.

- Remove duplicate sound resource declarations from CMakeLists.txt; sounds are already bundled in qmlmodules.

- Route debugView visibility through Data.Values.debugViewVisible singleton instead of direct ID cross-reference from TopBarSwipe, enabling DebugView to work correctly after CarView3D lazy-load.