### PR TITLE
Add QML unit tests for Cluster components

### DIFF
--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -14,7 +14,46 @@ permissions:
   actions: write
 
 jobs:
+  qml-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Qt 6.9.3
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.9.3'
+          modules: 'qtmultimedia qtserialbus qtquick3d qtshadertools'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl-dev libvulkan-dev
+
+      - name: Configure
+        run: |
+          qt-cmake -B build -S Cluster -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      - name: Build
+        run: |
+          cmake --build build --parallel
+
+      - name: Run QML tests
+        run: |
+          QT_QPA_PLATFORM=offscreen ./build/tests/tst_qmltests -o build/tests/reports/junit/results.xml,junitxml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qml-test-results
+          path: build/tests/reports/junit/results.xml
+
   trigger-codebuild:
+    needs: qml-tests
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -14,46 +14,7 @@ permissions:
   actions: write
 
 jobs:
-  qml-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install Qt 6.9.3
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.9.3'
-          modules: 'qtmultimedia qtserialbus qtserialport qtquick3d qtshadertools'
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl-dev libvulkan-dev
-
-      - name: Configure
-        run: |
-          qt-cmake -B build -S Cluster -DCMAKE_BUILD_TYPE=RelWithDebInfo
-
-      - name: Build
-        run: |
-          cmake --build build --parallel
-
-      - name: Run QML tests
-        run: |
-          QT_QPA_PLATFORM=offscreen ./build/tests/tst_qmltests -o build/tests/reports/junit/results.xml,junitxml
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: qml-test-results
-          path: build/tests/reports/junit/results.xml
-
   trigger-codebuild:
-    needs: qml-tests
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/boot2qt-build.yml
+++ b/.github/workflows/boot2qt-build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.9.3'
-          modules: 'qtmultimedia qtserialbus qtquick3d qtshadertools'
+          modules: 'qtmultimedia qtserialbus qtserialport qtquick3d qtshadertools'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-boot2qt.sh
+++ b/.github/workflows/build-boot2qt.sh
@@ -44,6 +44,16 @@ if [ -f "$TOOLCHAIN_ENV_SCRIPT" ]; then
   source "$TOOLCHAIN_ENV_SCRIPT"
   export OECORE_CMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE"
   
+  # Run QML unit tests using host Qt before cross-compiling
+  echo "=== Running QML Unit Tests ==="
+  cd $CODEBUILD_SRC_DIR/Cluster
+  mkdir -p build-host && cd build-host
+  $QT_DIR/gcc_64/bin/qt-cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  cmake --build . --target tst_qmltests --parallel 6
+  QT_QPA_PLATFORM=offscreen ./tests/tst_qmltests
+  echo "=== QML Tests Passed ==="
+  cd $CODEBUILD_SRC_DIR
+
   echo "Building Cluster Application for Boot to Qt (includes common library automatically)..."
   cd $CODEBUILD_SRC_DIR/Cluster
   mkdir build-boot2qt && cd build-boot2qt

--- a/Cluster/CMakeLists.txt
+++ b/Cluster/CMakeLists.txt
@@ -26,7 +26,8 @@ set(QML_IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY}
     FORCE
 )
 
-find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Qml Quick Multimedia SerialBus)
+find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Qml Quick Multimedia SerialBus QuickTest)
+enable_testing()
 
 # Include common library
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common ${CMAKE_BINARY_DIR}/common)
@@ -100,6 +101,8 @@ endif()
 if (LINK_INSIGHT)
     include(insight OPTIONAL)
 endif ()
+
+add_subdirectory(tests)
 
 include(GNUInstallDirs)
 install(TARGETS ${CMAKE_PROJECT_NAME}

--- a/Cluster/Cluster/Themes.qml
+++ b/Cluster/Cluster/Themes.qml
@@ -67,7 +67,7 @@ Item {
                 albumArt: "assets/stardustMirage.png"
                 trackArtist: "Stardust Mirage"
                 trackTitle: "Celestial Echoes"
-                trackspeed: 600
+                trackSpeed: 600
             }
         },
 

--- a/Cluster/ClusterContent/ClusterFigma/AdasComp.ui.qml
+++ b/Cluster/ClusterContent/ClusterFigma/AdasComp.ui.qml
@@ -18,6 +18,7 @@ Rectangle {
 
     Image {
         id: adasHaloVec
+        objectName: "adasHaloVec"
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.leftMargin: 17
@@ -27,6 +28,7 @@ Rectangle {
 
     Text {
         id: txtADASEng
+        objectName: "txtADASEng"
         width: 256
         height: 31
         color: "#818181"

--- a/Cluster/ClusterContent/ClusterFigma/BatteryGauge_Comp.ui.qml
+++ b/Cluster/ClusterContent/ClusterFigma/BatteryGauge_Comp.ui.qml
@@ -55,6 +55,7 @@ Rectangle {
 
     Rectangle {
         id: barFillingBattery
+        objectName: "barFillingBattery"
         color: "#67b800"
         radius: 1
         anchors.right: parent.right
@@ -99,6 +100,7 @@ Rectangle {
 
     Text {
         id: textBatteryRem
+        objectName: "textBatteryRem"
         x: barFillingBattery.x - 55
         y: 27
         width: 50

--- a/Cluster/ClusterContent/ClusterFigma/FuelGauge_Comp.ui.qml
+++ b/Cluster/ClusterContent/ClusterFigma/FuelGauge_Comp.ui.qml
@@ -27,6 +27,7 @@ Rectangle {
 
     Rectangle {
         id: veFuelGaugeBar
+        objectName: "veFuelGaugeBar"
         width: 0
         color: "#67b800"
         radius: 1
@@ -109,6 +110,7 @@ Rectangle {
 
     Text {
         id: txtFuelRem
+        objectName: "txtFuelRem"
         x: veFuelGaugeBar.width + 100
         y: 27
         width: 50

--- a/Cluster/ClusterContent/ClusterFigma/GearComp.ui.qml
+++ b/Cluster/ClusterContent/ClusterFigma/GearComp.ui.qml
@@ -16,6 +16,7 @@ Rectangle {
 
     Text {
         id: txtGearD
+        objectName: "txtGearD"
         y: 79
         width: 39
         height: 72
@@ -31,6 +32,7 @@ Rectangle {
 
     Text {
         id: txtGearR
+        objectName: "txtGearR"
         x: 6
         y: 43
         color: "#464646"
@@ -45,6 +47,7 @@ Rectangle {
 
     Text {
         id: txtGearP
+        objectName: "txtGearP"
         x: 6
         y: 0
         color: "#464646"

--- a/Cluster/ClusterContent/ClusterFigma/QsrTurnSignals.ui.qml
+++ b/Cluster/ClusterContent/ClusterFigma/QsrTurnSignals.ui.qml
@@ -14,6 +14,7 @@ Rectangle {
 
     SafeImage {
         id: turnLeftIcon
+        objectName: "turnLeftIcon"
         width: 50
         height: 50
         opacity: 0
@@ -25,6 +26,7 @@ Rectangle {
 
     SafeImage {
         id: turnRightIcon
+        objectName: "turnRightIcon"
         width: 50
         height: 50
         opacity: 0

--- a/Cluster/tests/CMakeLists.txt
+++ b/Cluster/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+qt_add_executable(tst_qmltests main.cpp)
+
+target_compile_definitions(tst_qmltests PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+target_link_libraries(tst_qmltests PRIVATE
+    Qt6::Gui
+    Qt6::QuickTest
+    Cluster
+    Clusterplugin
+    ClusterContent
+    ClusterContentplugin
+    VehicleData
+    VehicleDataplugin
+    antares_common
+)
+
+add_test(NAME tst_qmltests COMMAND tst_qmltests)

--- a/Cluster/tests/main.cpp
+++ b/Cluster/tests/main.cpp
@@ -1,0 +1,19 @@
+#include <QtQuickTest>
+#include <QCoreApplication>
+#include <QObject>
+
+class Setup : public QObject
+{
+    Q_OBJECT
+public slots:
+    void applicationAvailable()
+    {
+        QCoreApplication::setOrganizationName("QtProject");
+        QCoreApplication::setOrganizationDomain("qt.io");
+        QCoreApplication::setApplicationName("qmltests");
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(qmltests, Setup)
+
+#include "main.moc"

--- a/Cluster/tests/tst_AdasComp.qml
+++ b/Cluster/tests/tst_AdasComp.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtTest
+import ClusterContent
+
+Item {
+    id: root
+    width: 600
+    height: 700
+
+    Component {
+        id: adasCompComponent
+        AdasComp {
+            width: 480
+            height: 592
+            adasOFF: true
+            adasON: false
+        }
+    }
+
+    TestCase {
+        name: "AdasCompTests"
+        when: windowShown
+
+        function test_defaultState() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            compare(adas.state, qsTr("AdasOFF"))
+        }
+
+        function test_defaultProperties() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            compare(adas.adasOFF, true)
+            compare(adas.adasON, false)
+        }
+
+        function test_adasEngagedText() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            compare(adas.txtADASEngText, qsTr("ADAS ENGAGED"))
+        }
+
+        function test_switchToAdasON() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            adas.adasON = true
+            adas.adasOFF = false
+            tryCompare(adas, "state", "AdasON")
+        }
+
+        function test_switchBackToAdasOFF() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            adas.adasON = true
+            adas.adasOFF = false
+            tryCompare(adas, "state", "AdasON")
+            adas.adasON = false
+            adas.adasOFF = true
+            tryCompare(adas, "state", "AdasOFF")
+        }
+
+        function test_adasOFFHidesHalo() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            let halo = findChild(adas, "adasHaloVec")
+            verify(!!halo, "Object exists")
+            tryCompare(halo, "opacity", 0)
+        }
+
+        function test_adasONShowsHalo() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            let halo = findChild(adas, "adasHaloVec")
+            verify(!!halo, "Object exists")
+            adas.adasON = true
+            adas.adasOFF = false
+            tryCompare(adas, "state", "AdasON")
+            tryCompare(halo, "opacity", 1)
+        }
+
+        function test_adasOFFHidesEngagedText() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            let engText = findChild(adas, "txtADASEng")
+            verify(!!engText, "Object exists")
+            tryCompare(engText, "width", 0)
+        }
+
+        function test_adasONShowsEngagedText() {
+            let adas = createTemporaryObject(adasCompComponent, root)
+            verify(!!adas, "Component exists")
+            let engText = findChild(adas, "txtADASEng")
+            verify(!!engText, "Object exists")
+            adas.adasON = true
+            adas.adasOFF = false
+            tryCompare(adas, "state", "AdasON")
+            tryCompare(engText, "width", 257)
+        }
+    }
+}

--- a/Cluster/tests/tst_BatteryGauge_Comp.qml
+++ b/Cluster/tests/tst_BatteryGauge_Comp.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import QtTest
+import ClusterContent
+import VehicleData
+
+Item {
+    id: root
+    width: 700
+    height: 200
+
+    Component {
+        id: batteryGaugeComponent
+        BatteryGauge_Comp {
+            width: 647
+            height: 161
+        }
+    }
+
+    TestCase {
+        name: "BatteryGaugeCompTests"
+        when: windowShown
+
+        function test_componentCreation() {
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            compare(gauge.width, 647)
+            compare(gauge.height, 161)
+        }
+
+        function test_barExistsAndAccessible() {
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "barFillingBattery")
+            verify(!!bar, "Object exists")
+            compare(bar.color, '#67b800')
+        }
+
+        function test_textLabelExists() {
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "textBatteryRem")
+            verify(!!label, "Object exists")
+            compare(label.font.family, qsTr("Oxanium"))
+            compare(label.font.pixelSize, 30)
+        }
+
+        function test_barWidthAtFullBattery() {
+            let originalBattery = VehicleData.battery
+            VehicleData.battery = 100
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "barFillingBattery")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 371)
+            VehicleData.battery = originalBattery
+        }
+
+        function test_barWidthAtEmptyBattery() {
+            let originalBattery = VehicleData.battery
+            VehicleData.battery = 0
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "barFillingBattery")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 0)
+            VehicleData.battery = originalBattery
+        }
+
+        function test_barWidthAtHalfBattery() {
+            let originalBattery = VehicleData.battery
+            VehicleData.battery = 50
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "barFillingBattery")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 185.5)
+            VehicleData.battery = originalBattery
+        }
+
+        function test_labelHiddenAtFullBattery() {
+            let originalBattery = VehicleData.battery
+            VehicleData.battery = 100
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "textBatteryRem")
+            verify(!!label, "Object exists")
+            tryCompare(label, "opacity", 0)
+            VehicleData.battery = originalBattery
+        }
+
+        function test_labelVisibleAtLowBattery() {
+            let originalBattery = VehicleData.battery
+            VehicleData.battery = 50
+            let gauge = createTemporaryObject(batteryGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "textBatteryRem")
+            verify(!!label, "Object exists")
+            tryCompare(label, "opacity", 1)
+            VehicleData.battery = originalBattery
+        }
+    }
+}

--- a/Cluster/tests/tst_DateTime.qml
+++ b/Cluster/tests/tst_DateTime.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import QtTest
+import Cluster
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    TestCase {
+        name: "DateTimeTests"
+        when: windowShown
+
+        function test_singletonAccessible() {
+            verify(DateTime !== null)
+            compare(DateTime.timeString !== "", true)
+        }
+
+        function test_hoursInRange() {
+            verify(DateTime.hours >= 0)
+            verify(DateTime.hours <= 23)
+            compare(DateTime.hours >= 0 && DateTime.hours <= 23, true)
+        }
+
+        function test_minutesInRange() {
+            verify(DateTime.minutes >= 0)
+            verify(DateTime.minutes <= 59)
+            compare(DateTime.minutes >= 0 && DateTime.minutes <= 59, true)
+        }
+
+        function test_secondsInRange() {
+            verify(DateTime.seconds >= 0)
+            verify(DateTime.seconds <= 59)
+            compare(DateTime.seconds >= 0 && DateTime.seconds <= 59, true)
+        }
+
+        function test_dayInRange() {
+            verify(DateTime.day >= 0)
+            verify(DateTime.day <= 6)
+            compare(DateTime.day >= 0 && DateTime.day <= 6, true)
+        }
+
+        function test_dateInRange() {
+            verify(DateTime.date >= 1)
+            verify(DateTime.date <= 31)
+            compare(DateTime.date >= 1 && DateTime.date <= 31, true)
+        }
+
+        function test_monthInRange() {
+            verify(DateTime.month >= 0)
+            verify(DateTime.month <= 11)
+            compare(DateTime.month >= 0 && DateTime.month <= 11, true)
+        }
+
+        function test_timeStringFormat() {
+            let parts = DateTime.timeString.split(":")
+            compare(parts.length, 2)
+        }
+
+        function test_dateStringNotEmpty() {
+            compare(DateTime.dateString !== "", true)
+        }
+
+        function test_timeUpdatesWithinInterval() {
+            let initialSeconds = DateTime.seconds
+            wait(1500)
+            let secondsChanged = (DateTime.seconds !== initialSeconds)
+            compare(secondsChanged, true)
+        }
+    }
+}

--- a/Cluster/tests/tst_DriveMode.qml
+++ b/Cluster/tests/tst_DriveMode.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtTest
+import ClusterContent
+import VehicleData
+
+Item {
+    id: root
+    width: 400
+    height: 100
+
+    Component {
+        id: driveModeComponent
+        DriveMode {
+            width: 291
+            height: 35
+        }
+    }
+
+    TestCase {
+        name: "DriveModeTests"
+        when: windowShown
+
+        function test_componentCreation() {
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            compare(dm.width, 291)
+            compare(dm.height, 35)
+        }
+
+        function test_defaultDriveModeLabel() {
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            compare(dm.txtDriveModeText, qsTr("DRIVE MODE:"))
+        }
+
+        function test_driveModeReflectsVehicleData() {
+            let originalMode = VehicleData.driveMode
+            VehicleData.driveMode = "SPORT"
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            tryCompare(dm, "txtModeText", "SPORT")
+            VehicleData.driveMode = originalMode
+        }
+
+        function test_driveModeUpdatesOnChange() {
+            let originalMode = VehicleData.driveMode
+            VehicleData.driveMode = "SPORT"
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            tryCompare(dm, "txtModeText", "SPORT")
+            VehicleData.driveMode = "ECO"
+            tryCompare(dm, "txtModeText", "ECO")
+            VehicleData.driveMode = originalMode
+        }
+
+        function test_driveModeComfort() {
+            let originalMode = VehicleData.driveMode
+            VehicleData.driveMode = "COMFORT"
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            tryCompare(dm, "txtModeText", "COMFORT")
+            VehicleData.driveMode = originalMode
+        }
+
+        function test_driveModeLabelWritable() {
+            let dm = createTemporaryObject(driveModeComponent, root)
+            verify(!!dm, "Component exists")
+            dm.txtDriveModeText = qsTr("MODE:")
+            compare(dm.txtDriveModeText, qsTr("MODE:"))
+        }
+    }
+}

--- a/Cluster/tests/tst_FuelGauge_Comp.qml
+++ b/Cluster/tests/tst_FuelGauge_Comp.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import QtTest
+import ClusterContent
+import VehicleData
+
+Item {
+    id: root
+    width: 700
+    height: 200
+
+    Component {
+        id: fuelGaugeComponent
+        FuelGauge_Comp {
+            width: 589
+            height: 161
+        }
+    }
+
+    TestCase {
+        name: "FuelGaugeCompTests"
+        when: windowShown
+
+        function test_componentCreation() {
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            compare(gauge.width, 589)
+            compare(gauge.height, 161)
+        }
+
+        function test_barExistsAndAccessible() {
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "veFuelGaugeBar")
+            verify(!!bar, "Object exists")
+            compare(bar.color, '#67b800')
+        }
+
+        function test_textLabelExists() {
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "txtFuelRem")
+            verify(!!label, "Object exists")
+            compare(label.font.family, qsTr("Oxanium"))
+            compare(label.font.pixelSize, 30)
+        }
+
+        function test_barWidthAtFullFuel() {
+            let originalFuel = VehicleData.fuel
+            VehicleData.fuel = 100
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "veFuelGaugeBar")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 371)
+            VehicleData.fuel = originalFuel
+        }
+
+        function test_barWidthAtEmptyFuel() {
+            let originalFuel = VehicleData.fuel
+            VehicleData.fuel = 0
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "veFuelGaugeBar")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 0)
+            VehicleData.fuel = originalFuel
+        }
+
+        function test_barWidthAtHalfFuel() {
+            let originalFuel = VehicleData.fuel
+            VehicleData.fuel = 50
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let bar = findChild(gauge, "veFuelGaugeBar")
+            verify(!!bar, "Object exists")
+            tryCompare(bar, "width", 185.5)
+            VehicleData.fuel = originalFuel
+        }
+
+        function test_labelHiddenAtFullFuel() {
+            let originalFuel = VehicleData.fuel
+            VehicleData.fuel = 100
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "txtFuelRem")
+            verify(!!label, "Object exists")
+            tryCompare(label, "opacity", 0)
+            VehicleData.fuel = originalFuel
+        }
+
+        function test_labelVisibleAtLowFuel() {
+            let originalFuel = VehicleData.fuel
+            VehicleData.fuel = 50
+            let gauge = createTemporaryObject(fuelGaugeComponent, root)
+            verify(!!gauge, "Component exists")
+            let label = findChild(gauge, "txtFuelRem")
+            verify(!!label, "Object exists")
+            tryCompare(label, "opacity", 1)
+            VehicleData.fuel = originalFuel
+        }
+    }
+}

--- a/Cluster/tests/tst_GearComp.qml
+++ b/Cluster/tests/tst_GearComp.qml
@@ -1,0 +1,95 @@
+import QtQuick
+import QtTest
+import ClusterContent
+
+Item {
+    id: root
+    width: 200
+    height: 400
+
+    Component {
+        id: gearCompComponent
+        GearComp {
+            width: 51
+            height: 272
+        }
+    }
+
+    TestCase {
+        name: "GearCompTests"
+        when: windowShown
+
+        function test_defaultState() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            compare(gear.state, qsTr("Drive"))
+        }
+
+        function test_defaultModeProperties() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            compare(gear.modeDrive, true)
+            compare(gear.modePark, false)
+        }
+
+        function test_defaultGearText() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            compare(gear.txtGearDText, qsTr("D"))
+            compare(gear.txtGearR1Text, qsTr("P"))
+            compare(gear.txtGearRText, qsTr("R"))
+        }
+
+        function test_switchToPark() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            gear.modePark = true
+            gear.modeDrive = false
+            tryCompare(gear, "state", "Park")
+        }
+
+        function test_switchBackToDrive() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            gear.modePark = true
+            gear.modeDrive = false
+            tryCompare(gear, "state", "Park")
+            gear.modePark = false
+            gear.modeDrive = true
+            tryCompare(gear, "state", "Drive")
+        }
+
+        function test_parkStateGearPHighlighted() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            gear.modePark = true
+            gear.modeDrive = false
+            tryCompare(gear, "state", "Park")
+            let txtGearP = findChild(gear, "txtGearP")
+            verify(!!txtGearP, "Object exists")
+            tryCompare(txtGearP, "color", '#9e9ea0')
+            compare(txtGearP.font.pixelSize, 60)
+        }
+
+        function test_parkStateGearDDimmed() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            gear.modePark = true
+            gear.modeDrive = false
+            tryCompare(gear, "state", "Park")
+            let txtGearD = findChild(gear, "txtGearD")
+            verify(!!txtGearD, "Object exists")
+            tryCompare(txtGearD, "color", '#464646')
+            compare(txtGearD.font.pixelSize, 45)
+        }
+
+        function test_driveStateGearDHighlighted() {
+            let gear = createTemporaryObject(gearCompComponent, root)
+            verify(!!gear, "Component exists")
+            let txtGearD = findChild(gear, "txtGearD")
+            verify(!!txtGearD, "Object exists")
+            compare(txtGearD.color, '#9b9b9b')
+            compare(txtGearD.font.pixelSize, 60)
+        }
+    }
+}

--- a/Cluster/tests/tst_QsrTurnSignals.qml
+++ b/Cluster/tests/tst_QsrTurnSignals.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import QtTest
+import ClusterContent
+
+Item {
+    id: root
+    width: 600
+    height: 100
+
+    Component {
+        id: turnSignalsComponent
+        QsrTurnSignals {
+            width: 500
+            height: 60
+            turnLeftSignal: false
+            turnRightSignal: false
+        }
+    }
+
+    TestCase {
+        name: "QsrTurnSignalsTests"
+        when: windowShown
+
+        function test_defaultState() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            compare(signals.state, "")
+        }
+
+        function test_defaultSignalProperties() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            compare(signals.turnLeftSignal, false)
+            compare(signals.turnRightSignal, false)
+        }
+
+        function test_turnLeftStateActivated() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            signals.turnLeftSignal = true
+            tryCompare(signals, "state", "TurnLeft")
+        }
+
+        function test_turnRightStateActivated() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            signals.turnRightSignal = true
+            tryCompare(signals, "state", "TurnRight")
+        }
+
+        function test_turnLeftIconVisible() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            let leftIcon = findChild(signals, "turnLeftIcon")
+            verify(!!leftIcon, "Object exists")
+            compare(leftIcon.opacity, 0)
+            signals.turnLeftSignal = true
+            tryCompare(signals, "state", "TurnLeft")
+            tryCompare(leftIcon, "opacity", 1)
+        }
+
+        function test_turnRightIconVisible() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            let rightIcon = findChild(signals, "turnRightIcon")
+            verify(!!rightIcon, "Object exists")
+            compare(rightIcon.opacity, 0)
+            signals.turnRightSignal = true
+            tryCompare(signals, "state", "TurnRight")
+            tryCompare(rightIcon, "opacity", 1)
+        }
+
+        function test_turnLeftHidesRightIcon() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            let rightIcon = findChild(signals, "turnRightIcon")
+            verify(!!rightIcon, "Object exists")
+            signals.turnLeftSignal = true
+            tryCompare(signals, "state", "TurnLeft")
+            tryCompare(rightIcon, "opacity", 0)
+        }
+
+        function test_signalDeactivated() {
+            let signals = createTemporaryObject(turnSignalsComponent, root)
+            verify(!!signals, "Component exists")
+            let leftIcon = findChild(signals, "turnLeftIcon")
+            verify(!!leftIcon, "Object exists")
+            signals.turnLeftSignal = true
+            tryCompare(signals, "state", "TurnLeft")
+            signals.turnLeftSignal = false
+            tryCompare(signals, "state", "")
+        }
+    }
+}

--- a/Cluster/tests/tst_Themes.qml
+++ b/Cluster/tests/tst_Themes.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import QtTest
+import Cluster
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    TestCase {
+        name: "ThemesTests"
+        when: windowShown
+
+        function test_singletonAccessible() {
+            verify(Themes !== null)
+            compare(Themes.currentTheme, qsTr("luna"))
+        }
+
+        function test_defaultThemeColors() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "luna"
+            tryCompare(Themes, "themeColor1", '#ace1cc')
+            tryCompare(Themes, "themeColor2", '#395b85')
+            tryCompare(Themes, "themeColor3", '#b793a3')
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_defaultTrackMetadata() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "luna"
+            compare(Themes.trackArtist, qsTr("Luna Nova"))
+            compare(Themes.trackTitle, qsTr("Midnight Serenade"))
+            compare(Themes.trackSpeed, 600)
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_stardustThemeColors() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "stardust"
+            tryCompare(Themes, "themeColor1", '#bd4c35')
+            compare(Themes.themeColor2, '#8e4362')
+            compare(Themes.themeColor3, '#8f3329')
+            compare(Themes.trackArtist, qsTr("Stardust Mirage"))
+            compare(Themes.trackTitle, qsTr("Celestial Echoes"))
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_pixelThemeColors() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "pixel"
+            tryCompare(Themes, "themeColor1", '#65a08f')
+            compare(Themes.themeColor2, '#fd825f')
+            compare(Themes.themeColor3, '#2f4c62')
+            compare(Themes.trackArtist, qsTr("Pixel Pulse"))
+            compare(Themes.trackTitle, qsTr("Digital Dreams"))
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_electricThemeColors() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "electric"
+            tryCompare(Themes, "themeColor1", '#db3e47')
+            compare(Themes.themeColor2, '#4d5674')
+            compare(Themes.themeColor3, '#b93971')
+            compare(Themes.trackArtist, qsTr("Electric Dreamscape"))
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_nextTrackCycles() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "luna"
+            tryCompare(Themes, "state", "luna")
+            Themes.nextTrack()
+            tryCompare(Themes, "state", "electric")
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_previousTrackCycles() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "luna"
+            tryCompare(Themes, "state", "luna")
+            Themes.previousTrack()
+            tryCompare(Themes, "state", "stardust")
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_nextTrackWrapsAround() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "velvet"
+            tryCompare(Themes, "state", "velvet")
+            Themes.nextTrack()
+            tryCompare(Themes, "state", "stardust")
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_previousTrackWrapsAround() {
+            let originalTheme = Themes.currentTheme
+            Themes.currentTheme = "stardust"
+            tryCompare(Themes, "state", "stardust")
+            Themes.previousTrack()
+            tryCompare(Themes, "state", "velvet")
+            Themes.currentTheme = originalTheme
+        }
+
+        function test_songsListComplete() {
+            compare(Themes.songs.length, 12)
+            compare(Themes.songs[0], qsTr("stardust"))
+            compare(Themes.songs[11], qsTr("velvet"))
+        }
+    }
+}

--- a/common/qml/VehicleData/VehicleData.qml
+++ b/common/qml/VehicleData/VehicleData.qml
@@ -143,4 +143,12 @@ Item {
      * @note Controls visibility of quick status icons in the UI
      */
     property bool qsrIcons: false
+
+    /**
+     * @brief Current theme identifier
+     * @type {string}
+     * @default "luna"
+     * @note Used to sync theme selection across components
+     */
+    property string theme: "luna"
 }


### PR DESCRIPTION
## Summary
- Add Qt Quick Test infrastructure and 68 test cases covering 8 Cluster QML components: Themes, DateTime, GearComp, QsrTurnSignals, AdasComp, BatteryGauge, FuelGauge, and DriveMode
- Fix `trackspeed` typo in Themes.qml stardust state (`trackspeed` -> `trackSpeed`) — property assignment was silently ignored
- Add missing `theme` property to VehicleData QML mock, fixing broken `onThemeChanged` Connections handler in Themes.qml
- Add `objectName` declarations to 5 source components for test accessibility via `findChild`

## Test plan
- [x] All 68 tests pass (84 including init/cleanup): `QT_QPA_PLATFORM=offscreen ./build_macos/tests/tst_qmltests`
- [x] No QML runtime warnings (trackspeed typo and onThemeChanged signal mismatch both resolved)
- [x] Build succeeds on macOS with Qt 6.9.3
- [ ] Verify tests pass on CI (Linux offscreen)
- [ ] Review HTML coverage report for identified gaps (conflicting states, out-of-range gauges, untested themes)